### PR TITLE
Add ThreadTree, a tree-structured thread pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+name: Continuous integration
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+          - 1.42.0  # MSRV
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - run: cargo test -v --no-fail-fast

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 crossbeam-channel = "0.5"
+parking_lot = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ crossbeam-channel = "0.5"
 
 [dev-dependencies]
 once_cell = "1.5"
+
+[features]
+unstable-thread-sea = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "joinpool"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["bluss <>"]
 edition = "2018"
 
 [dependencies]
 crossbeam-channel = "0.5"
-parking_lot = "*"
+
+[dev-dependencies]
+once_cell = "1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,22 @@
 [package]
-name = "joinpool"
+name = "thread-tree"
 version = "0.2.0"
 authors = ["bluss <>"]
 edition = "2018"
+
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+
+repository = "https://github.com/bluss/thread-tree"
+documentation = "https://docs.rs/thread-tree"
+description = """
+A tree-structured thread pool for splitting jobs hierarchically on worker threads.
+
+The tree structure means that there is no contention between workers when delivering jobs.
+"""
+
+keywords = ["threadpool", "thread", "pool", "tree", "parallelism"]
+categories = ["concurrency"]
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/README.md
+++ b/README.md
@@ -19,4 +19,18 @@ Ideas
 
 Always have threads >= 1
 
-Shrink threads by messaging Exit message - first thread to pick up, is free and exits
+Shrink threads by messaging Exit message - first thread to pick up, is free and
+exits
+
+Have a tree structure of thread pool subgroups? To mimic the branching split of
+nested joins.
+Thread Pool in 4 is a 2 -> 2 split; and 8 is a 2 -> 2 -> 2 split.
+
+Maybe have a way to "reserve" a subbranch of this. Build a 16 => 2 -> 2 -> 2 ->
+2 structure, and make it possible to reserve a subtree of that(!)
+
+But: remember that a "2" group only needs one thread (current thread is
+excluded). How does this translate to the thread tree? Maybe it doesn't.
+
+Serve 8 jobs by having a 7-thread pool; split it and serve each half, 4 jobs, with a 3 thread pool.
+This is done by integrating the "join(A, B)" operation with the split into sub-threadpools.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-## Joinpool
+## Thread tree
 
-Based on rayon-core by Niko Matsakis and Josh Stone.
+A tree-structured thread pool.
+
+Stack jobs and job execution based on rayon-core by Niko Matsakis and Josh Stone.
 
 Experimental simple thread pool used for spawning stack-bound scoped jobs with no work stealing.
 
@@ -15,22 +17,7 @@ This is not good for:
 
 
 
-Ideas
+### Wild ideas and notes
 
-Always have threads >= 1
+Possibly allow reserving a subbranch of the tree.
 
-Shrink threads by messaging Exit message - first thread to pick up, is free and
-exits
-
-Have a tree structure of thread pool subgroups? To mimic the branching split of
-nested joins.
-Thread Pool in 4 is a 2 -> 2 split; and 8 is a 2 -> 2 -> 2 split.
-
-Maybe have a way to "reserve" a subbranch of this. Build a 16 => 2 -> 2 -> 2 ->
-2 structure, and make it possible to reserve a subtree of that(!)
-
-But: remember that a "2" group only needs one thread (current thread is
-excluded). How does this translate to the thread tree? Maybe it doesn't.
-
-Serve 8 jobs by having a 7-thread pool; split it and serve each half, 4 jobs, with a 3 thread pool.
-This is done by integrating the "join(A, B)" operation with the split into sub-threadpools.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,9 @@
+Version 0.2.0
+=============
+
+First crates.io version.
+
+New features
+------------
+
+- ThreadTree, the tree-structured thread pool by [@bluss]

--- a/src/job.rs
+++ b/src/job.rs
@@ -8,7 +8,7 @@ use super::unwind;
 pub enum JobResult<T> {
     None,
     Ok(T),
-    Panic(Box<Any + Send>),
+    Panic(Box<dyn Any + Send>),
 }
 
 // from rayon

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,7 @@ impl ThreadTree {
     /// The following example shows using a two-level tree and using context to spawn tasks.
     ///
     /// ```
-    /// use joinpool::{ThreadTree, ThreadTreeCtx};
+    /// use thread_tree::{ThreadTree, ThreadTreeCtx};
     ///
     /// let tp = ThreadTree::new_with_level(2);
     ///

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -21,7 +21,7 @@ where
     panic::catch_unwind(AssertUnwindSafe(func))
 }
 
-pub fn resume_unwinding(payload: Box<Any + Send>) -> ! {
+pub fn resume_unwinding(payload: Box<dyn Any + Send>) -> ! {
     panic::resume_unwind(payload)
 }
 


### PR DESCRIPTION
A hierarchical thread pool used for splitting work in an branching fashion.

See [`ThreadTree::new_with_level()`] to create a new thread tree,
and see [`ThreadTree::top()`] for a usage example.

The thread tree has the benefit that at each level, jobs can be sent directly to the thread                                                                   that is going to execute it - that means there is no contention between waiting threads. The                                                                  downside is that the structure of the thread tree is rather static.   


The ThreadSea code in this PR is experimental and not intended to be used. It's somewhat uncleanly
being included but cfg-ed out.